### PR TITLE
Add basic stock options scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# IBKR Superbot
+
+This is a simple example script that uses `yfinance` to fetch options data for selected tickers.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the scanner:
+
+```bash
+python scanner.py
+```
+
+The script will repeatedly fetch options expiration dates for a few example tickers every minute.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+yfinance

--- a/scanner.py
+++ b/scanner.py
@@ -1,0 +1,24 @@
+import time
+import yfinance as yf
+
+
+def scan(tickers):
+    results = {}
+    for ticker in tickers:
+        try:
+            t = yf.Ticker(ticker)
+            opts = t.options
+            results[ticker] = opts
+            print(f"{ticker}: {len(opts)} option expiration dates found.")
+        except Exception as e:
+            print(f"Error fetching {ticker}: {e}")
+    return results
+
+
+if __name__ == "__main__":
+    tickers = ["AAPL", "GOOGL", "TSLA"]
+    while True:
+        print(f"Scanning tickers {tickers}")
+        scan(tickers)
+        time.sleep(60)
+


### PR DESCRIPTION
## Summary
- add simple options scanning script using `yfinance`
- add requirements file
- document setup and usage in README

## Testing
- `python scanner.py` *(fails: network access to fc.yahoo.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686d3d52aa7883219e717badf2ff99d0