### PR TITLE
Implement minimal self‑learning trading bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# IBKR Superbot
+
+This repository contains a minimal example of a self-learning trading bot. It uses the `yfinance` package to download historical market data and a simple Q-learning algorithm for generating buy/sell/hold signals.
+
+## Features
+- Fetches historical prices for multiple tickers
+- Basic Q-learning strategy that learns from price movements
+- Skeleton code to connect to Interactive Brokers using `ib_insync` (see `bot/execution.py`)
+
+## Running
+```
+python -m bot.main TICKER1 TICKER2
+```
+This will download recent price data and train the Q-learning trader. The resulting Q-table is printed for demonstration.
+
+## Disclaimer
+This code is for educational purposes only and should not be used for live trading without significant improvements and thorough testing. Penny stocks and options are highly risky and require careful analysis and compliance with regulations.

--- a/bot/data.py
+++ b/bot/data.py
@@ -1,0 +1,19 @@
+import yfinance as yf
+import pandas as pd
+from typing import List
+
+def fetch_price_history(tickers: List[str], period: str = "1y", interval: str = "1d") -> pd.DataFrame:
+    """Fetch historical price data for tickers using yfinance."""
+    data = []
+    for ticker in tickers:
+        try:
+            df = yf.download(ticker, period=period, interval=interval, progress=False)
+            if df.empty:
+                continue
+            df["Ticker"] = ticker
+            data.append(df)
+        except Exception as exc:
+            print(f"Failed to download {ticker}: {exc}")
+    if data:
+        return pd.concat(data)
+    return pd.DataFrame()

--- a/bot/execution.py
+++ b/bot/execution.py
@@ -1,0 +1,16 @@
+from ib_insync import MarketOrder, IB, Stock, Option
+from typing import List
+
+class IBExecutor:
+    def __init__(self, host: str = '127.0.0.1', port: int = 7497, client_id: int = 1):
+        self.ib = IB()
+        self.ib.connect(host, port, client_id)
+
+    def place_order(self, symbol: str, action: str, quantity: int, is_option: bool = False):
+        contract = Option(symbol, '20250117', 0, 'C', 'SMART') if is_option else Stock(symbol, 'SMART', 'USD')
+        order = MarketOrder(action, quantity)
+        trade = self.ib.placeOrder(contract, order)
+        return trade
+
+    def disconnect(self):
+        self.ib.disconnect()

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,23 @@
+import argparse
+from .data import fetch_price_history
+from .strategy import QLearningTrader
+#from .execution import IBExecutor
+
+
+def run(tickers):
+    data = fetch_price_history(tickers, period="1mo", interval="1d")
+    trader = QLearningTrader()
+    trader.train(data)
+    # For demonstration we just print the Q-table
+    print(trader.q_table)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple self-learning trading bot")
+    parser.add_argument('tickers', nargs='+', help='Tickers to trade')
+    args = parser.parse_args()
+    run(args.tickers)
+
+
+if __name__ == '__main__':
+    main()

--- a/bot/strategy.py
+++ b/bot/strategy.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pandas as pd
+
+class QLearningTrader:
+    def __init__(self, alpha: float = 0.1, gamma: float = 0.95, epsilon: float = 0.1):
+        self.alpha = alpha
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.q_table = {}
+
+    def _get_state(self, row: pd.Series) -> str:
+        direction = 'up' if row['Close'] >= row['Open'] else 'down'
+        return direction
+
+    def choose_action(self, state: str) -> str:
+        if np.random.rand() < self.epsilon or state not in self.q_table:
+            return np.random.choice(['buy', 'sell', 'hold'])
+        return max(self.q_table[state], key=self.q_table[state].get)
+
+    def update(self, state: str, action: str, reward: float, next_state: str):
+        if state not in self.q_table:
+            self.q_table[state] = {a: 0.0 for a in ['buy', 'sell', 'hold']}
+        if next_state not in self.q_table:
+            self.q_table[next_state] = {a: 0.0 for a in ['buy', 'sell', 'hold']}
+        q_predict = self.q_table[state][action]
+        q_target = reward + self.gamma * max(self.q_table[next_state].values())
+        self.q_table[state][action] += self.alpha * (q_target - q_predict)
+
+    def train(self, data: pd.DataFrame):
+        for i in range(len(data) - 1):
+            row = data.iloc[i]
+            next_row = data.iloc[i + 1]
+            state = self._get_state(row)
+            next_state = self._get_state(next_row)
+            action = self.choose_action(state)
+            reward = next_row['Close'] - row['Close'] if action == 'buy' else row['Close'] - next_row['Close']
+            self.update(state, action, reward, next_state)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ib_insync
+yfinance
+numpy
+pandas

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,7 @@
+import pandas as pd
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from bot.data import fetch_price_history
+
+def test_fetch_price_history():
+    df = fetch_price_history(["AAPL"], period="1d", interval="1d")
+    assert isinstance(df, pd.DataFrame)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,13 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+from bot.strategy import QLearningTrader
+
+
+def test_trader_learns():
+    data = pd.DataFrame({
+        'Open': [1, 2, 3],
+        'Close': [2, 1, 4]
+    })
+    trader = QLearningTrader(alpha=0.5, gamma=0.9, epsilon=0.0)
+    trader.train(data)
+    assert trader.q_table


### PR DESCRIPTION
## Summary
- add skeleton Q-learning trading bot with data fetch and execution placeholders
- document setup and usage in README
- provide simple tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3cf8cda4832192b4f00069e798a1